### PR TITLE
fix: header styling

### DIFF
--- a/components/AppBar/index.js
+++ b/components/AppBar/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import MaterialAppBar from '@material-ui/core/AppBar';
+import { styled } from '@material-ui/core/styles';
+
+const StyledAppBar = styled(MaterialAppBar)({
+  justifyContent: 'space-between',
+  background: 'white',
+  position: 'static',
+});
+
+const AppBar = (props) => <StyledAppBar {...props} />;
+
+export default AppBar;

--- a/components/Toolbar/index.js
+++ b/components/Toolbar/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import MaterialToolbar from '@material-ui/core/Toolbar';
+import { styled } from '@material-ui/core/styles';
+
+const StyledToolbar = styled(MaterialToolbar)({
+  display: 'flex',
+  justifyContent: 'space-between',
+});
+
+
+const Toolbar = (props) => <StyledToolbar {...props} />;
+
+
+export default Toolbar;

--- a/components/TopNav/index.js
+++ b/components/TopNav/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { styled } from '@material-ui/core/styles';
+import Link from '../Link';
+
+const StyledLink = styled(Link)(({ theme }) => ({
+  color: theme.palette.primary.main,
+  textDecoration: 'none',
+  fontSize: '16px',
+}));
+
+const List = styled('ul')({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginLeft: 'auto',
+  listStyle: 'none',
+});
+
+const ListItem = styled('li')(({ theme }) => ({
+  marginRight: theme.spacing(3),
+}));
+
+
+const TopNav = () => (
+  <nav>
+    <List>
+      <ListItem>
+        <StyledLink href="/about">
+              About
+        </StyledLink>
+      </ListItem>
+      <ListItem>
+        <StyledLink href="/my-account">
+              My Account
+        </StyledLink>
+      </ListItem>
+    </List>
+  </nav>
+);
+
+export default TopNav;

--- a/components/Typography/index.js
+++ b/components/Typography/index.js
@@ -1,0 +1,3 @@
+import Typography from '@material-ui/core/Typography';
+
+export default Typography;

--- a/containers/header/Header.js
+++ b/containers/header/Header.js
@@ -1,59 +1,26 @@
-import { Toolbar, AppBar, Typography } from '@material-ui/core';
-import { makeStyles, styled } from '@material-ui/core/styles';
+import { Typography } from '@material-ui/core';
+import { styled } from '@material-ui/core/styles';
+import AppBar from '../../components/AppBar';
+import Toolbar from '../../components/Toolbar';
 import Link from '../../components/Link';
+import TopNav from '../../components/TopNav';
 
-
-const useStyles = makeStyles((theme) => ({
-  appBar: {
-    justifyContent: 'space-between',
-  },
-  ul: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    marginLeft: 'auto',
-    listStyle: 'none',
-  },
-  li: {
-    marginRight: theme.spacing(3),
-  },
+const HeaderLogo = styled(Link)(({ theme }) => ({
+  color: theme.palette.primary.main,
+  textDecoration: 'none',
 }));
 
-const HeaderLogo = styled(Link)({
-  color: 'white',
-  textDecoration: 'none',
-});
-const HeaderLink = styled(Link)({
-  color: 'white',
-  textDecoration: 'none',
-  fontSize: '16px',
-});
-
-const Header = () => {
-  const classes = useStyles();
-
-  return (
-    <AppBar position="static">
-      <Toolbar>
-        <Typography variant="h4">
-          <HeaderLogo href="/" color="primary">
+const Header = () => (
+  <AppBar>
+    <Toolbar>
+      <Typography variant="h4">
+        <HeaderLogo href="/" color="primary">
             Fundes
-          </HeaderLogo>
-        </Typography>
-        <ul className={classes.ul}>
-          <li className={classes.li}>
-            <HeaderLink href="/about">
-              About
-            </HeaderLink>
-          </li>
-          <li className={classes.li}>
-            <HeaderLink href="/my-account">
-              My Account
-            </HeaderLink>
-          </li>
-        </ul>
-      </Toolbar>
-    </AppBar>
-  );
-};
+        </HeaderLogo>
+      </Typography>
+      <TopNav />
+    </Toolbar>
+  </AppBar>
+);
 
 export default Header;

--- a/containers/header/Header.js
+++ b/containers/header/Header.js
@@ -1,5 +1,5 @@
-import { Typography } from '@material-ui/core';
 import { styled } from '@material-ui/core/styles';
+import Typography from '../../components/Typography';
 import AppBar from '../../components/AppBar';
 import Toolbar from '../../components/Toolbar';
 import Link from '../../components/Link';


### PR DESCRIPTION
Refactors `Header` to use a new and consistent approach to styling. 

- This uses `Material-UI`'s 'styled' API. It is a version of `styled-components`.
- We import material components into the component folder of our repo first and apply any necessary styling or modifications to the elements.
- Then our containers and composite components import these modified components and implement them.